### PR TITLE
Raise an error if any hook execution fails

### DIFF
--- a/lib/mikoshi/plan.rb
+++ b/lib/mikoshi/plan.rb
@@ -5,6 +5,8 @@ require 'erb'
 require 'yaml'
 
 module Mikoshi
+  HookExecutionError = Class.new(StandardError)
+
   class Plan
     class Base
       attr_reader :data, :client
@@ -19,7 +21,7 @@ module Mikoshi
 
       def invoke_hooks(hooks)
         hooks.each do |hook|
-          system hook
+          raise(HookExecutionError, hook) unless system(hook)
         end
       end
     end

--- a/spec/mikoshi/plan_spec.rb
+++ b/spec/mikoshi/plan_spec.rb
@@ -32,13 +32,24 @@ RSpec.describe 'Mikoshi::Plan::Base' do
     end
   end
 
-  context '#invoke_hooks' do
+  describe '#invoke_hooks' do
     let(:client) { Aws::ECS::Client.new(stub_responses: true) }
     let(:plan) do
       Mikoshi::Plan::Base.new(yaml_path: 'spec/yaml/task_definitions/ping2googledns.yml.erb', client: client)
     end
-    let(:commands) { ['echo hello'] }
 
-    it { expect { plan.invoke_hooks(commands) }.to output("hello\n").to_stdout_from_any_process }
+    subject do
+      -> { plan.invoke_hooks(commands) }
+    end
+
+    context 'when hook execution succeeds' do
+      let(:commands) { ['echo hello'] }
+      it { is_expected.to output("hello\n").to_stdout_from_any_process }
+    end
+
+    context 'when hook execution fails' do
+      let(:commands) { ['false'] }
+      it { is_expected.to raise_error Mikoshi::HookExecutionError }
+    end
   end
 end


### PR DESCRIPTION
Deployment should be interrupted if a hook such as database migration process fails