### PR TITLE
Add cli option 'group'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,3 +11,6 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*_spec.rb'
     - 'mikoshi.gemspec'
+
+Metrics/CyclomaticComplexity:
+  Max: 8

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Waiting for 10 sec...
 Waiting for 10 sec...
 Update service success
 
+# if task definition and service are same name, you can use -g option
+$ mikoshi deploy -g ping2googledns
+
 # show help
 $ mikoshi help
 Commands:

--- a/lib/mikoshi/cli.rb
+++ b/lib/mikoshi/cli.rb
@@ -41,9 +41,14 @@ module Mikoshi
     desc 'deploy', 'Deploy task definition and service'
     method_option :task_definition, type: :string, desc: 'task_definition name', aliases: '-t'
     method_option :service, type: :string, desc: 'service name', aliases: '-s'
+    method_option :group, type: :string, desc: 'service and task definition name(if both are same)', aliases: '-g'
+
     def deploy
-      update_task_definition(options[:task_definition]) unless options[:task_definition].nil?
-      update_service(options[:service]) unless options[:service].nil?
+      task_definition = options[:group] || options[:task_definition] || nil
+      service = options[:group] || options[:service] || nil
+
+      update_task_definition(task_definition) if task_definition
+      update_service(service) if service
     end
 
     no_tasks do


### PR DESCRIPTION
if service name and task definition name are same, pass it once use
-g option. e.g.

```
$ bundle exec mikoshi deploy -g some-app
$ bundle exec mikoshi deploy -s some-app -t some-app # same
```