### PR TITLE
Remove unneed options when update_service

### DIFF
--- a/lib/mikoshi/plan/service.rb
+++ b/lib/mikoshi/plan/service.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/except'
 require 'mikoshi/plan'
+require 'mikoshi/util/except_keys'
 
 module Mikoshi
   class Plan
     class Service < Base
       TASK_DEFINITION_WITH_REVISION = %r{\A\S+:\d+\z}
+      IGNORE_OPTIONS_WHEN_UPDATE =
+        %i[client_token load_balancers placement_constraints placement_strategy role service_name].freeze
 
       def initialize(yaml_path: nil, client: nil)
         super
@@ -30,7 +32,7 @@ module Mikoshi
       def update_service
         invoke_before_update_hooks
 
-        @client.update_service(@data[:service].except(:service_name, :placement_strategy, :placement_constraints))
+        @client.update_service(@data[:service].except_keys(IGNORE_OPTIONS_WHEN_UPDATE))
         wait_until_services_stable
 
         invoke_after_update_hooks

--- a/lib/mikoshi/util/except_keys.rb
+++ b/lib/mikoshi/util/except_keys.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/hash/except'
+
+class Hash
+  def except_keys(keys_enum)
+    return dup.except!(keys_enum) unless keys_enum.respond_to?(:each)
+
+    clone = dup
+    keys_enum.each do |key|
+      clone.except!(key)
+    end
+
+    clone
+  end
+end

--- a/spec/mikoshi/util/except_keys_spec.rb
+++ b/spec/mikoshi/util/except_keys_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'mikoshi/util/except_keys'
+
+RSpec.describe 'Hash#except_keys' do
+  let(:data) do
+    {
+      a: 'one',
+      b: 'two',
+      c: 'three',
+    }
+  end
+
+  context 'pass single key' do
+    it { expect(data.except_keys(:b)).to eq(a: 'one', c: 'three') }
+  end
+
+  context 'pass multiple keys with array' do
+    it { expect(data.except_keys(%i[a b])).to eq(c: 'three') }
+  end
+end

--- a/spec/yaml/services/ping2googledns.yml.erb
+++ b/spec/yaml/services/ping2googledns.yml.erb
@@ -3,6 +3,11 @@ service:
   service: "ping2googledns"
   task_definition: <%= "ping2googledns:#{ENV['TASK_DEF_REVISION']}" %>
   desired_count: 0
+  role: "arn:aws:iam::123456789:role/someRole"
+  load_balancers:
+    - target_group_arn: "arn:aws:elasticloadbalancing:ap-northeast-1:123456789:targetgroup/ping2googledns/123456789abcdef"
+      container_name: "ping"
+      container_port: 80
   placement_strategy:
     - type: "spread"
       field: "attribute:ecs.availability-zone"


### PR DESCRIPTION
Options that client_token, load_balancers, placement_constraints, placement_strategy, role, and service_name are unneeded and raised an error from aws-sdk when passing update_service function.